### PR TITLE
Double bar support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /node_modules
 /yarn.lock
+todo.md

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-# CSV To Markdown Table
+# CSV To Plain Text Table
 
-[![npm version](https://badge.fury.io/js/csv-to-markdown-table.svg)](https://badge.fury.io/js/csv-to-markdown-table)
-[![Build Status](https://travis-ci.org/donatj/CsvToMarkdownTable.svg?branch=master)](https://travis-ci.org/donatj/CsvToMarkdownTable)
+[![Build Status](https://travis-ci.org/terriann/CsvToPlainTextTable.svg?branch=master)](https://travis-ci.org/donatj/CsvToMarkdownTable)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/donatj/csvtomarkdowntable/master/LICENSE.md)
 
-Simple JavaScript CSV to Markdown Table Converter
+A simple JavaScript CSV to Markdown Table converter with Confluence Markup support
 
-You can see it in action and play with the [Live Example](https://donatstudios.com/CsvToMarkdownTable).
+Forked from [donatj/CsvToMarkdownTable](https://github.com/donatj/CsvToMarkdownTable)
 
 Requires **no external libraries**. Works in Node as well as in the browser.
 
+### For Markdown Markup
+
 Example Use:
 
-```js
-csvToMarkdown( "header1,header2,header3\nValue1,Value2,Value3", ",", true);
-```
+    csvToMarkdown( "header1,header2,header3\nValue1,Value2,Value3", ",", true);
 
 Outputs:
 
@@ -24,8 +23,21 @@ Outputs:
 | Value1  | Value2  | Value3  | 
 ```
 
-Which displays in markdown as:
+Which displays in Markdown as:
 
 | header1 | header2 | header3 | 
 |---------|---------|---------| 
 | Value1  | Value2  | Value3  | 
+
+### For Confluence Markup
+
+Example Use:
+
+    csvToMarkdown( "header1,header2,header3\nValue1,Value2,Value3", ",", true, true);
+
+Outputs:
+
+```
+|| header1 || header2 || header3 || 
+|  Value1  |  Value2  |  Value3  | 
+```

--- a/example.html
+++ b/example.html
@@ -32,6 +32,7 @@
 
 		var headerCheckbox = document.getElementById('has-headers');
 		var delimiterMarker = document.getElementById('delimiter-marker');
+		var headerStyle = document.getElementById('header-style');
 
 		var getDelimiter = function () {
 			var delim = delimiterMarker.value;
@@ -40,6 +41,15 @@
 			}
 
 			return delim;
+		};
+
+		var getheaderStyle = function () {
+			let style = headerStyle.value;
+			let useDoubleHeader = false;
+			if (style == '||') {
+				useDoubleHeader = true;
+			}
+			return useDoubleHeader;
 		};
 
 		var populateData = document.getElementById('populate-data');
@@ -55,12 +65,13 @@
 			var value = input.value.trim();
 			var hasHeader = headerCheckbox.checked;
 
-			output.value = csvToMarkdown(value, getDelimiter(), hasHeader);
+			output.value = csvToMarkdown(value, getDelimiter(), hasHeader, getheaderStyle());
 		};
 
 		input.addEventListener('keyup', renderTable);
 		headerCheckbox.addEventListener('change', renderTable);
 		delimiterMarker.addEventListener('change', renderTable);
+		headerStyle.addEventListener('change', renderTable);
 
 		populateData.addEventListener('change', function () {
 			input.value = populateData.value.split("|").join(getDelimiter()) + "\n";
@@ -86,18 +97,23 @@
 <body>
 	<textarea style="width: 100%; height: 200px;" id="tsv-input"></textarea>
 	<label><input type="checkbox" id="has-headers" /> Use first line as headers</label>
+	<select id="header-style">
+		<option>-- Header Style --</option>
+		<option value="||">Double Bar Line</option>
+		<option value="|---|">Separator Line</option>
+	</select>
 	<select id="delimiter-marker">
-	<option value="tab">Tab Separated</option>
-	<option value=",">Comma Separated</option>
-	<option value=";">Semicolon Separated</option>
-</select>
+		<option value="tab">Tab Separated</option>
+		<option value=",">Comma Separated</option>
+		<option value=";">Semicolon Separated</option>
+	</select>
 	<select id="populate-data">
-	<option>-- Populate With --</option>
-	<option value="id|select_type|table|type|possible_keys|key|key_len|ref|rows|extra">MySQL EXPLAIN Headers</option>
-	<option value="id|select_type|table|type|possible_keys|key|key_len|ref|rows|filtered|extra">MySQL EXPLAIN EXTENDED
-		Headers
-	</option>
-</select>
+		<option>-- Populate With --</option>
+		<option value="id|select_type|table|type|possible_keys|key|key_len|ref|rows|extra">MySQL EXPLAIN Headers</option>
+		<option value="id|select_type|table|type|possible_keys|key|key_len|ref|rows|filtered|extra">MySQL EXPLAIN EXTENDED
+			Headers
+		</option>
+	</select>
 
 	<hr>
 	<textarea style="width: 100%; height: 200px;" id="table-output" readonly></textarea>

--- a/lib/CsvToMarkdown.d.ts
+++ b/lib/CsvToMarkdown.d.ts
@@ -4,6 +4,7 @@
  * @param {string} csvContent - The string content of the CSV
  * @param {string} delimiter - The character(s) to use as the CSV column delimiter
  * @param {boolean} hasHeader - Whether to use the first row of Data as headers
+ * @param {boolean} useDoubleBarHeader - Whether the header uses double barlines for <th>
  * @returns {string}
  */
-declare function csvToMarkdown(csvContent: string, delimiter?: string, hasHeader?: boolean): string;
+declare function csvToMarkdown(csvContent: string, delimiter?: string, hasHeader?: boolean, useDoubleBarHeader?: boolean): string;

--- a/lib/CsvToMarkdown.js
+++ b/lib/CsvToMarkdown.js
@@ -48,12 +48,12 @@ function csvToMarkdown(csvContent, delimiter, hasHeader, useDoubleBarHeader) {
     tabularData.forEach(function (col, i) {
         maxRowLen.forEach(function (len, y) {
             var row = typeof col[y] == "undefined" ? "" : col[y];
-            var headerWidth = useDoubleBarHeader ? 2 : 1;
-            var pre_space_count = (i > 0) ? headerWidth : 1;
+            var pre_space_count = 1;
             var post_space_count = (len - row.length) + 1;
             if (useDoubleBarHeader) {
                 if (i > 0) {
                     post_space_count++;
+                    pre_space_count++;
                     if (y > 0) {
                         pre_space_count--;
                     }

--- a/lib/CsvToMarkdown.js
+++ b/lib/CsvToMarkdown.js
@@ -5,11 +5,13 @@
  * @param {string} csvContent - The string content of the CSV
  * @param {string} delimiter - The character(s) to use as the CSV column delimiter
  * @param {boolean} hasHeader - Whether to use the first row of Data as headers
+ * @param {boolean} useDoubleBarHeader - Whether the header uses double barlines for <th>
  * @returns {string}
  */
-function csvToMarkdown(csvContent, delimiter, hasHeader) {
+function csvToMarkdown(csvContent, delimiter, hasHeader, useDoubleBarHeader) {
     if (delimiter === void 0) { delimiter = "\t"; }
     if (hasHeader === void 0) { hasHeader = false; }
+    if (useDoubleBarHeader === void 0) { useDoubleBarHeader = false; }
     if (delimiter != "\t") {
         csvContent = csvContent.replace(/\t/g, "    ");
     }
@@ -46,8 +48,26 @@ function csvToMarkdown(csvContent, delimiter, hasHeader) {
     tabularData.forEach(function (col, i) {
         maxRowLen.forEach(function (len, y) {
             var row = typeof col[y] == "undefined" ? "" : col[y];
-            var spacing = Array((len - row.length) + 1).join(" ");
-            var out = "| " + row + spacing + " ";
+            var headerWidth = useDoubleBarHeader ? 2 : 1;
+            var pre_space_count = (i > 0) ? headerWidth : 1;
+            var post_space_count = (len - row.length) + 1;
+            if (useDoubleBarHeader) {
+                if (i > 0) {
+                    post_space_count++;
+                    if (y > 0) {
+                        pre_space_count--;
+                    }
+                }
+                if (!hasHeader && i === 0) {
+                    post_space_count++;
+                    if (y === 0) {
+                        pre_space_count++;
+                    }
+                }
+            }
+            var preSpacing = Array(pre_space_count + 1).join(" ");
+            var spacing = Array(post_space_count + 1).join(" ");
+            var out = "|" + preSpacing + row + spacing;
             if (hasHeader && i === 0) {
                 headerOutput += out;
             }
@@ -62,6 +82,10 @@ function csvToMarkdown(csvContent, delimiter, hasHeader) {
             rowOutput += "| \n";
         }
     });
+    if (useDoubleBarHeader) {
+        headerOutput = headerOutput.replace(/\|/g, '||');
+        seperatorOutput = '';
+    }
     return headerOutput + seperatorOutput + rowOutput;
 }
 if (typeof module != "undefined") {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "csv-to-markdown-table",
-  "description": "JavaScript/Node.js Csv to Markdown Table Converter",
+  "name": "cav-to-plain-text-table",
+  "description": "A Simple JavaScript/Node.js CSV to Markdown Table Converter with Confluence Markup Support Edit",
   "main": "./lib/CsvToMarkdown.js",
-  "version": "0.4.0",
+  "version": "0.1.0",
   "types": "./lib/CsvToMarkdown.d.js",
   "scripts": {
     "test": "node_modules/.bin/mocha test"
@@ -14,7 +14,10 @@
   "keywords": [
     "csv",
     "markdown",
-    "github"
+    "github",
+    "jira",
+    "confluence",
+    "confluence markup"
   ],
   "author": {
     "name": "Jesse G. Donat",
@@ -23,9 +26,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/donatj/CsvToMarkdownTable/issues"
+    "url": "https://github.com/terriann/CsvToPlainTextTable/issues"
   },
-  "homepage": "https://donatstudios.com/CsvToMarkdownTable",
+  "homepage": "",
   "devDependencies": {
     "@types/node": "^7.0.12",
     "@types/requirejs": "^2.1.29",

--- a/src/CsvToMarkdown.ts
+++ b/src/CsvToMarkdown.ts
@@ -4,9 +4,10 @@
  * @param {string} csvContent - The string content of the CSV
  * @param {string} delimiter - The character(s) to use as the CSV column delimiter
  * @param {boolean} hasHeader - Whether to use the first row of Data as headers
+ * @param {boolean} useDoubleBarHeader - Whether the header uses double barlines for <th>
  * @returns {string}
  */
-function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: boolean = false) {
+function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: boolean = false, useDoubleBarHeader: boolean = false) {
 	if (delimiter != "\t") {
 		csvContent = csvContent.replace(/\t/g, "    ");
 	}
@@ -53,8 +54,31 @@ function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: 
 	tabularData.forEach((col, i) => {
 		maxRowLen.forEach((len, y) => {
 			const row = typeof col[y] == "undefined" ? "" : col[y];
-			const spacing = Array((len - row.length) + 1).join(" ");
-			const out = `| ${row}${spacing} `;
+			const headerWidth = useDoubleBarHeader ? 2 : 1;
+
+			let pre_space_count = (i > 0) ? headerWidth : 1;
+			let post_space_count = (len - row.length ) + 1;
+
+			if(useDoubleBarHeader) {
+				if(i > 0 ){
+					post_space_count++;
+					if(y > 0){
+						pre_space_count--;
+					}
+				}
+				if(!hasHeader && i===0){
+					post_space_count++;
+					if(y === 0) {
+						pre_space_count++;
+					}
+				}
+			}
+			
+			const preSpacing = Array(pre_space_count + 1).join(" ");
+			const spacing = Array(post_space_count + 1).join(" ");
+
+			const out = `|${preSpacing}${row}${spacing}`;
+			
 			if (hasHeader && i === 0) {
 				headerOutput += out;
 			} else {
@@ -68,6 +92,11 @@ function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: 
 			rowOutput += "| \n";
 		}
 	});
+
+	if(useDoubleBarHeader) {
+		headerOutput = headerOutput.replace(/\|/g, '||');
+		seperatorOutput = '';
+	}
 
 	return headerOutput + seperatorOutput + rowOutput;
 }

--- a/src/CsvToMarkdown.ts
+++ b/src/CsvToMarkdown.ts
@@ -54,14 +54,13 @@ function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: 
 	tabularData.forEach((col, i) => {
 		maxRowLen.forEach((len, y) => {
 			const row = typeof col[y] == "undefined" ? "" : col[y];
-			const headerWidth = useDoubleBarHeader ? 2 : 1;
-
-			let pre_space_count = (i > 0) ? headerWidth : 1;
+			let pre_space_count = 1;
 			let post_space_count = (len - row.length ) + 1;
 
 			if(useDoubleBarHeader) {
 				if(i > 0 ){
 					post_space_count++;
+					pre_space_count++;
 					if(y > 0){
 						pre_space_count--;
 					}
@@ -76,7 +75,6 @@ function csvToMarkdown(csvContent: string, delimiter: string = "\t", hasHeader: 
 			
 			const preSpacing = Array(pre_space_count + 1).join(" ");
 			const spacing = Array(post_space_count + 1).join(" ");
-
 			const out = `|${preSpacing}${row}${spacing}`;
 			
 			if (hasHeader && i === 0) {

--- a/test/test.js
+++ b/test/test.js
@@ -12,11 +12,6 @@ describe('csvToMarkdown', function () {
 		assert.equal(result, "| a | b | c | \n|---|---|---| \n");
 	});
 
-	it('should return a table with headers and no data', function () {
-		var result = csvToMarkdown("a\tb\tc", "\t", true);
-		assert.equal(result, "| a | b | c | \n|---|---|---| \n");
-	});
-
 	it('should convert tabs to 4 spaces to work on github', function () {
 		var result = csvToMarkdown("a\tb\tc", ";", false);
 		assert.equal(result, "|             | \n|-------------| \n| a    b    c | \n");
@@ -31,4 +26,9 @@ describe('csvToMarkdown', function () {
 		var result = csvToMarkdown('"a, b, c, d",e', ",", false);
 		assert.equal(result, '|              |   | \n|--------------|---| \n| "a, b, c, d" | e | \n');
 	})
+
+	it('should format correctly with double bar header style', function () {
+		var result = csvToMarkdown("a,b,c\nx,y,z", ",", true, true);
+		assert.equal(result, "|| a || b || c || \n| x | y | z | \n");
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,12 @@ describe('csvToMarkdown', function () {
 	})
 
 	it('should format correctly with double bar header style', function () {
-		var result = csvToMarkdown("a,b,c\nx,y,z", ",", true, true);
-		assert.equal(result, "|| a || b || c || \n| x | y | z | \n");
+		var result = csvToMarkdown("1,2 - 4,34\nab,c,d\nab,c,d", ",", true, true);
+		assert.equal(result, "|| 1  || 2 - 4 || 34 || \n|  ab  | c      | d   | \n|  ab  | c      | d   | \n");
+	});
+
+	it('should format correctly with double bar header style', function () {
+		var result = csvToMarkdown("1,2 - 4,34\nab,c,d\nab,c,d", ",", false, true);
+		assert.equal(result, "||    ||       ||    || \n|  1   | 2 - 4  | 34  | \n|  ab  | c      | d   | \n|  ab  | c      | d   | \n");
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -27,13 +27,13 @@ describe('csvToMarkdown', function () {
 		assert.equal(result, '|              |   | \n|--------------|---| \n| "a, b, c, d" | e | \n');
 	})
 
-	it('should format correctly with double bar header style', function () {
-		var result = csvToMarkdown("1,2 - 4,34\nab,c,d\nab,c,d", ",", true, true);
-		assert.equal(result, "|| 1  || 2 - 4 || 34 || \n|  ab  | c      | d   | \n|  ab  | c      | d   | \n");
+	it('should format correctly with double bar header style using the first line as a header', function () {
+		var result = csvToMarkdown("key,sandwich,points,notes\n1,Chicken Salad,48,With just enough seasoning\n2,Turkey & Bacon,263,Healthy but with bacon\n3,Bologna and cheese,1,Classic Favorite", ",", true, true);
+		assert.equal(result, "|| key || sandwich           || points || notes                      || \n|  1    | Chicken Salad       | 48      | With just enough seasoning  | \n|  2    | Turkey & Bacon      | 263     | Healthy but with bacon      | \n|  3    | Bologna and cheese  | 1       | Classic Favorite            | \n");
 	});
 
-	it('should format correctly with double bar header style', function () {
-		var result = csvToMarkdown("1,2 - 4,34\nab,c,d\nab,c,d", ",", false, true);
-		assert.equal(result, "||    ||       ||    || \n|  1   | 2 - 4  | 34  | \n|  ab  | c      | d   | \n|  ab  | c      | d   | \n");
+	it('should format correctly with double bar header style with a blank header', function () {
+		var result = csvToMarkdown("1,Chicken Salad,48,With just enough seasoning\n2,Turkey & Bacon,263,Healthy but with bacon\n3,Bologna and cheese,1,Classic Favorite", ",", false, true);
+		assert.equal(result, "||   ||                    ||     ||                            || \n|  1  | Chicken Salad       | 48   | With just enough seasoning  | \n|  2  | Turkey & Bacon      | 263  | Healthy but with bacon      | \n|  3  | Bologna and cheese  | 1    | Classic Favorite            | \n");
 	});
 });


### PR DESCRIPTION
Rename fork to continue supporting the double barline header style used by Confluence Markup as described in donatj/CsvToMarkdownTable#5